### PR TITLE
2014 announcement post

### DIFF
--- a/content/news/2014-02-20-SciPy2014-Announce.rst
+++ b/content/news/2014-02-20-SciPy2014-Announce.rst
@@ -24,12 +24,12 @@ Specialized Tracks
 ===================
 This year we are happy to announce two specialized tracks that run in parallel to the general conference:
 
-** Scientific Computing in Education **
+**Scientific Computing in Education**
 
 
 Thanks to efforts such as Software Carpentry, the Hacker Within and grassroots Python Bootcamps, teaching scientific computing as a discipline is becoming more widely accepted and recognized as a crucial task in developing scientific literacy. This special track will focus on efforts to promote and develop scientific computing education, as well as related topics such as reproducibility and best practices for scientific computing.
 
-** Geospatial Data in Science **
+**Geospatial Data in Science**
 
 
 Python has become a core component of organiziing, understanding, and visualizing geospatial data. This track will focus on libraries, tools and techniques for processing Geospatial data of all types and for all purposes -- from low-volume to high-volume, local and global.


### PR DESCRIPTION
Adding a new post to the conference blog to announce the conference. What else do I need to do to make it show up on http://conference.scipy.org/? Could we somehow have a news feed page inside SciPy2014 which grabs all the posts with Category: SciPy?

This attempts to address https://github.com/scipy-conference/SciPy-2014/issues/62
