### PR TITLE
EuroSciPy proceedings 2014 (+fix 2013)

### DIFF
--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -2,7 +2,7 @@ Title: Proceedings of the Python in Science Conferences
 URL: proceedings/index.html
 Save_as: proceedings/index.html
 
-**[EuroSciPy 2014](http://arxiv.org/abs/1412.7030v1)**
+**[EuroSciPy 2014](http://arxiv.org/abs/1412.7030)**
  *7th European Conference on Python in Science (EuroSciPy 2014) - Cambridge, UK (August 27 - 30, 2014)*
 
 **[EuroSciPy 2013](http://arxiv.org/abs/1405.0166)**

--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -2,6 +2,9 @@ Title: Proceedings of the Python in Science Conferences
 URL: proceedings/index.html
 Save_as: proceedings/index.html
 
+**[EuroSciPy 2014](http://arxiv.org/abs/1412.7030v1)**
+ *7th European Conference on Python in Science (EuroSciPy 2014) - Cambridge, UK (August 27 - 30, 2014)*
+
 **[EuroSciPy 2013](http://arxiv.org/html/1405.0166v1)**
  *6th European Conference on Python in Science (EuroSciPy 2013) - Brussels, Belgium (August 21 - 25, 2013)*
 

--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -5,7 +5,7 @@ Save_as: proceedings/index.html
 **[EuroSciPy 2014](http://arxiv.org/abs/1412.7030v1)**
  *7th European Conference on Python in Science (EuroSciPy 2014) - Cambridge, UK (August 27 - 30, 2014)*
 
-**[EuroSciPy 2013](http://arxiv.org/html/1405.0166v1)**
+**[EuroSciPy 2013](http://arxiv.org/abs/1405.0166)**
  *6th European Conference on Python in Science (EuroSciPy 2013) - Brussels, Belgium (August 21 - 25, 2013)*
 
 **[SciPy 2013](http://conference.scipy.org/proceedings/scipy2013)**  


### PR DESCRIPTION
Hi,

The proceedings for EuroSciPy 2014 are online, here is the link. I also fixed the link for 2013 that pointed to the html page instead of the abstract page.

Thanks