### PR TITLE
Enh/add proceedings for 2016

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,6 @@ publish:
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 
 rsync: publish
-	rsync -rvz -e ssh output/ conference.scipy.org:/home/scipy/site/conference/ 
+	rsync -rvz -e ssh output/ conference:/home/scipy/site/conference/ 
 
 .PHONY: html help clean regenerate serve devserver publish rsync

--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -2,6 +2,9 @@ Title: Proceedings of the Python in Science Conferences
 URL: proceedings/index.html
 Save_as: proceedings/index.html
 
+**[SciPy 2016](http://conference.scipy.org/proceedings/scipy2016)**
+ *15th Python in Science Conference - Austin, Texas (July 11 - 17, 2016)*
+
 **[SciPy 2015](http://conference.scipy.org/proceedings/scipy2015)**
  *14th Python in Science Conference - Austin, Texas (July 6 - 12, 2015)*
 

--- a/content/proceedings/google_analytics.js
+++ b/content/proceedings/google_analytics.js
@@ -1,0 +1,9 @@
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-30141106-1']);
+_gaq.push(['_trackPageview']);
+
+(function() {
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();

--- a/content/proceedings/proc_links.js
+++ b/content/proceedings/proc_links.js
@@ -1,0 +1,14 @@
+function proc_versions() {
+   var versions = ['2016', '2015', '2014', '2013', '2011', '2010', '2009', '2008'];
+   var proc_url = 'http://conference.scipy.org/proceedings/scipy';
+   document.write('<ul id="navibar">');
+
+   for (i=0; i < versions.length; i++) {
+       document.write('<li class="wikilink">');
+       document.write('<a href="' + proc_url + versions[i] + '">SciPy ' + versions[i] +  '</a>');
+       document.write('</li>');
+   }
+
+   document.write('</ul>');
+}
+

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -50,7 +50,7 @@ TRANSLATION_FEED_ATOM = None
 
 DEFAULT_PAGINATION = 5
 
-STATIC_PATHS = ['images', 'pdf', 'CNAME']
+STATIC_PATHS = ['images', 'pdf', 'CNAME', 'proceedings']
 
 # Uncomment following line if you want document-relative URLs when developing
 #RELATIVE_URLS = True


### PR DESCRIPTION
Proceedings have been uploaded to the server. This PR adds a link on this page http://conference.scipy.org/proceedings/. It is already live.