### PR TITLE
ENH: adds ISSN and DOI to index page

### DIFF
--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -2,6 +2,9 @@ Title: Proceedings of the Python in Science Conferences
 URL: proceedings/index.html
 Save_as: proceedings/index.html
 
+**ISSN: 2575-9752**
+**[https://doi.org/10.25080/issn.2575-9752](https://doi.org/10.25080/issn.2575-9752)**
+
 **[SciPy 2017](http://conference.scipy.org/proceedings/scipy2017)**
  *16th Python in Science Conference - Austin, Texas (July 10 - 16, 2017)*
 


### PR DESCRIPTION
Adds the conference level DOI and ISSN (identifiers for all
proceedings for all time) to the landing page for the
proceedings. xref:
https://github.com/scipy-conference/scipy_proceedings/issues/332