### PR TITLE
update index.html to 2018 SciPy and EuroSciPy

### DIFF
--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,11 +19,11 @@ The conferences generally consists of multiple days of tutorials followed by two
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="http://scipy2017.scipy.org/ehome/220975/493388/">SciPy 2017</a></h3>
-<p>Austin, TX, July 10-16, 2017</p>
+<h3><a href="https://scipy2018.scipy.org/">SciPy 2018</a></h3>
+<p>Austin, TX, July 9-15, 2018</p>
 
-<h3><a href="https://www.euroscipy.org/">EuroSciPy 2017</a></h3>
-<p>Erlangen, Germany</p>
+<h3><a href="https://www.euroscipy.org/">EuroSciPy 2018</a></h3>
+<p>Trento, Italy, August 28 - September 1, 2018</p>
 
 </div>
 


### PR DESCRIPTION
Updated URLs and text from 2017 to 2018 conference information.