### PR TITLE
Update index and add EuroScipy 2018

### DIFF
--- a/theme/tuxlite_zf/templates/article_list.html
+++ b/theme/tuxlite_zf/templates/article_list.html
@@ -4,49 +4,5 @@
 
 {% block top_content %}{% endblock %}
 
-{% if articles %}
-    {% for article in articles_page.object_list %}        
 
-        {# First item #}
-        {% if loop.first and not articles_page.has_previous() %}
-            <article>
-                <a href="{{ SITEURL }}/{{ article.url }}"><h3 class="article-title">{{ article.title }}</h3></a>
-                {% include 'article_infos.html' %}{{ article.content }}{% include 'article_infos_bottom.html' %}{% include 'comments.html' %}
-            </article>
-
-            {% if loop.length == 1 %}
-                {% include 'pagination.html' %}
-            {% endif %}
-
-            {% if loop.length > 1 %}
-                <hr  class="gradient"/>
-            {% endif %}
-
-        {# other items #}
-        {% else %}
-
-            <article>
-                <a href="{{ SITEURL }}/{{ article.url }}"><h3 class="article-title">{{ article.title }}</h3></a>
-                {% include 'article_infos.html' %}{{ article.summary }}{% include 'article_infos_bottom.html' %}{% include 'comments.html' %}
-                <a class="button radius secondary small right" href="{{ SITEURL }}/{{ article.url }}">Read More</a>
-                <hr  class="gradient"/>
-            </article>
-        {% endif %}
-
-        {% if loop.last %}
-            <!-- /#posts-list -->
-            {% if loop.last and (articles_page.has_previous() or not articles_page.has_previous() and loop.length > 1) %}
-                {% include 'pagination.html' %}
-            {% endif %}
-        {% endif %}
-    {% endfor %}
-
-{% else %}
-
-    <h3>Pages</h3>
-    {% for page in PAGES %}
-        <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
-    {% endfor %}
-
-{% endif %}
 {% endblock content %}

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,16 +19,15 @@ The conferences generally consists of multiple days of tutorials followed by two
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="http://scipy2017.scipy.org/ehome/220975/493388/">SciPy 2017</a></h3>
-<p>Austin, TX, July 10-16, 2017</p>
+<h3> <a href="https://scipy2018.scipy.org/ehome/index.php?eventid=299527&">SciPy 2018</a></h3> 
+<p>Austin, TX, July 9-15, 2018</p>
 
-<h3><a href="https://www.euroscipy.org/">EuroSciPy 2017</a></h3>
-<p>Erlangen, Germany</p>
+<h3><a href="https://www.euroscipy.org/2018">EuroSciPy 2018</a></h3>
+<p>Trento, Italy, Aug 28-Sep 1, 2018</p>
 
 </div>
 
 
 <hr/>
 
-<h2>Recent News</h2>
 {% endblock %}


### PR DESCRIPTION
This PR removes the listing of articles on the main page. All the articles were pretty old and there is no publication planned at the moment.  When needed, we can easily archive the old articles and restore the list on the index page.