### PR TITLE
ENH: update conference links for 2019

### DIFF
--- a/content/pages/past.md
+++ b/content/pages/past.md
@@ -1,6 +1,10 @@
-Title: Past Conferences 
+Title: Past Conferences
 URL: past.html
 Save_as: past.html
+
+## 2018
+* [SciPy 2018](http://scipy2018.scipy.org/)
+* [EuroSciPy 2018](https://www.euroscipy.org/2018/)
 
 ## 2017
 * [SciPy 2017](http://scipy2017.scipy.org/)
@@ -27,23 +31,23 @@ Save_as: past.html
 
 ## 2012
 * [SciPy 2012](http://conference.scipy.org/scipy2012/)
-* [EuroSciPy 2012](http://www.euroscipy.org/conference/euroscipy2012) 
-* [SciPy.in 2012](http://scipy.in/scipyin/2012/) 
+* [EuroSciPy 2012](http://www.euroscipy.org/conference/euroscipy2012)
+* [SciPy.in 2012](http://scipy.in/scipyin/2012/)
 
 ## 2011
-* [SciPy 2011](http://conference.scipy.org/scipy2011/) 
-* [EuroSciPy 2011](http://www.euroscipy.org/conference/euroscipy2011) 
-* [SciPy.in 2011](http://scipy.in/scipyin/2011/) 
+* [SciPy 2011](http://conference.scipy.org/scipy2011/)
+* [EuroSciPy 2011](http://www.euroscipy.org/conference/euroscipy2011)
+* [SciPy.in 2011](http://scipy.in/scipyin/2011/)
 
 ## 2010
-* [SciPy 2010](http://conference.scipy.org/scipy2010/) 
-* [EuroSciPy 2010](http://www.euroscipy.org/conference/euroscipy2010) 
-* [SciPy.in 2010](http://scipy.in/scipyin/2010/) 
+* [SciPy 2010](http://conference.scipy.org/scipy2010/)
+* [EuroSciPy 2010](http://www.euroscipy.org/conference/euroscipy2010)
+* [SciPy.in 2010](http://scipy.in/scipyin/2010/)
 
 ## 2009
-* [SciPy 2009](http://conference.scipy.org/SciPy2009/) 
-* [EuroSciPy 2009](http://www.euroscipy.org/conference/euroscipy2009) 
+* [SciPy 2009](http://conference.scipy.org/SciPy2009/)
+* [EuroSciPy 2009](http://www.euroscipy.org/conference/euroscipy2009)
 
 ## 2008
-* [SciPy 2008](http://conference.scipy.org/SciPy2008/) 
-* [EuroSciPy 2008](http://www.euroscipy.org/conference/869) 
+* [SciPy 2008](http://conference.scipy.org/SciPy2008/)
+* [EuroSciPy 2008](http://www.euroscipy.org/conference/869)

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,8 +19,8 @@ The conferences generally consists of multiple days of tutorials followed by two
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="https://scipy2018.scipy.org/ehome/index.php?eventid=299527">SciPy 2018</a></h3>
-<p>Austin, TX, July 9-15, 2018</p>
+<h3><a href="https://www.scipy2019.scipy.org/">SciPy 2019</a></h3>
+<p>Austin, TX July 8-14, 2019</p>
 
 </div>
 


### PR DESCRIPTION
Adds 2019 scipy conference to index page; updates past conferences with 2018.