### PR TITLE
Update information regarding the server hosting the site

### DIFF
--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -5,51 +5,51 @@ Save_as: proceedings/index.html
 **ISSN: 2575-9752**
 **[https://doi.org/10.25080/issn.2575-9752](https://doi.org/10.25080/issn.2575-9752)**
 
-**[SciPy 2021](http://conference.scipy.org/proceedings/scipy2021)**
+**[SciPy 2021](https://conference.scipy.org/proceedings/scipy2021)**
  *20th Python in Science Conference - Austin, Texas (July 12 - 18, 2021)*
 
-**[SciPy 2020](http://conference.scipy.org/proceedings/scipy2020)**
+**[SciPy 2020](https://conference.scipy.org/proceedings/scipy2020)**
  *19th Python in Science Conference - Austin, Texas (July 6 - 12, 2020)*
 
-**[SciPy 2019](http://conference.scipy.org/proceedings/scipy2019)**
+**[SciPy 2019](https://conference.scipy.org/proceedings/scipy2019)**
  *18th Python in Science Conference - Austin, Texas (July 8 - 14, 2019)*
 
-**[SciPy 2018](http://conference.scipy.org/proceedings/scipy2018)**
+**[SciPy 2018](https://conference.scipy.org/proceedings/scipy2018)**
  *17th Python in Science Conference - Austin, Texas (July 9 - 15, 2018)*
 
-**[SciPy 2017](http://conference.scipy.org/proceedings/scipy2017)**
+**[SciPy 2017](https://conference.scipy.org/proceedings/scipy2017)**
  *16th Python in Science Conference - Austin, Texas (July 10 - 16, 2017)*
 
-**[SciPy 2016](http://conference.scipy.org/proceedings/scipy2016)**
+**[SciPy 2016](https://conference.scipy.org/proceedings/scipy2016)**
  *15th Python in Science Conference - Austin, Texas (July 11 - 17, 2016)*
 
-**[SciPy 2015](http://conference.scipy.org/proceedings/scipy2015)**
+**[SciPy 2015](https://conference.scipy.org/proceedings/scipy2015)**
  *14th Python in Science Conference - Austin, Texas (July 6 - 12, 2015)*
 
 **[EuroSciPy 2014](http://arxiv.org/abs/1412.7030)**
  *7th European Conference on Python in Science (EuroSciPy 2014) - Cambridge, UK (August 27 - 30, 2014)*
 
-**[SciPy 2014](http://conference.scipy.org/proceedings/scipy2014)**
+**[SciPy 2014](https://conference.scipy.org/proceedings/scipy2014)**
  *13th Python in Science Conference - Austin, Texas (July 6 - 13, 2014)*
 
 **[EuroSciPy 2013](http://arxiv.org/abs/1405.0166)**
  *6th European Conference on Python in Science (EuroSciPy 2013) - Brussels, Belgium (August 21 - 25, 2013)*
 
-**[SciPy 2013](http://conference.scipy.org/proceedings/scipy2013)**
+**[SciPy 2013](https://conference.scipy.org/proceedings/scipy2013)**
  *12th Python in Science Conference - Austin, Texas (June 24 - 29, 2013)*
 
-**[SciPy 2012](http://conference.scipy.org/proceedings/scipy2012)**
+**[SciPy 2012](https://conference.scipy.org/proceedings/scipy2012)**
  *11th Python in Science Conference - Austin, Texas (July 16-21, 2012)*
 
-**[SciPy 2011](http://conference.scipy.org/proceedings/scipy2011)**
+**[SciPy 2011](https://conference.scipy.org/proceedings/scipy2011)**
  *10th Python in Science Conference - Austin, Texas (July 11 - 16, 2011)*
 
-**[SciPy 2010](http://conference.scipy.org/proceedings/scipy2010)**
+**[SciPy 2010](https://conference.scipy.org/proceedings/scipy2010)**
  *9th Python in Science Conference - Austin, Texas (June 28 - 30, 2010)*
 
-**[SciPy 2009](http://conference.scipy.org/proceedings/scipy2009)**
+**[SciPy 2009](https://conference.scipy.org/proceedings/scipy2009)**
  *8th Python in Science Conference - Austin, Texas (August 18 - 23, 2009)*
 
 
-**[SciPy 2008](http://conference.scipy.org/proceedings/scipy2008)**
+**[SciPy 2008](https://conference.scipy.org/proceedings/scipy2008)**
  *7th Python in Science Conference - Austin, Texas (June 28 - July 30, 2008)*


### PR DESCRIPTION
This PR updates the information regarding the server hosting the site. We;ve migrated the site from the rackspace server to an S3 bucket serving the static content.

I can provide access credentials to anyone needing to push to the S3 bucket.
