### PR TITLE
Add dates for SciPy 2023

### DIFF
--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,8 +19,8 @@ The conferences generally consists of multiple days of tutorials followed by two
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="https://www.scipy2022.scipy.org/">SciPy 2022</a></h3>
-<p>Austin, TX July 11-17, 2022</p>
+<h3>SciPy 2023</h3>
+<p>Austin, TX, July 10-16, 2023</p>
 
 </div>
 


### PR DESCRIPTION
We'll need to link the header once the scipy2023.scipy.org site is live.