### PR TITLE
Github action to publish to Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Build website
+        run: make clean && make publish
+
+      - name: Commit output to gh-pages branch
+        run: |
+            git config user.name "Automated"
+            git config user.email "actions@users.noreply.github.com"
+            timestamp=$(date -u +%FT%T%z)
+            ghp-import -m "Generate Pelican site ${timestamp}" --no-history --branch gh-pages  output
+            git push origin gh-pages
+        

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "hatchling.build"
 name = "conference_scipy"
 classifiers = ["Private :: Do Not Upload"]
 version = "0"
-dependencies = ["markdown", "pelican"]
+dependencies = ["markdown", "pelican", "ghp-import"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ docutils==0.20.1
     # via pelican
 feedgenerator==2.1.0
     # via pelican
+ghp-import==2.1.0
+    # via conference_scipy (pyproject.toml)
 idna==3.6
     # via anyio
 jinja2==3.1.3
@@ -33,7 +35,9 @@ pygments==2.17.2
     #   pelican
     #   rich
 python-dateutil==2.9.0.post0
-    # via pelican
+    # via
+    #   ghp-import
+    #   pelican
 pytz==2024.1
     # via feedgenerator
 rich==13.7.1


### PR DESCRIPTION
This uses the "publish from branch" method instead of the beta "publish from action."

I use `ghp-import` to simply making the history-free commit of `output/` to the `gh-pages` branch.

I still need to set up the CNAME and custom domain.

- PyPI link: https://pypi.org/project/ghp-import/
- Pages publish docs: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site

