### PR TITLE
Github Action to automatically publish PRs to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,5 +46,5 @@ jobs:
             git config user.email "actions@users.noreply.github.com"
             timestamp=$(date -u +%FT%T%z)
             ghp-import -m "Generate Pelican site ${timestamp}" --no-history --branch gh-pages  output
-            git push --force-with-lease origin gh-pages
+            git push --force origin gh-pages
         

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,5 +46,5 @@ jobs:
             git config user.email "actions@users.noreply.github.com"
             timestamp=$(date -u +%FT%T%z)
             ghp-import -m "Generate Pelican site ${timestamp}" --no-history --branch gh-pages  output
-            git push origin gh-pages
+            git push --force-with-lease origin gh-pages
         

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Build website
+        run: make clean && make publish
+
+      - name: Commit output to gh-pages branch
+        run: |
+            git config user.name "Automated"
+            git config user.email "actions@users.noreply.github.com"
+            timestamp=$(date -u +%FT%T%z)
+            ghp-import -m "Generate Pelican site ${timestamp}" --no-history --branch gh-pages  output
+            git push origin gh-pages
+        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,6 @@ jobs:
             git config user.name "Automated"
             git config user.email "actions@users.noreply.github.com"
             timestamp=$(date -u +%FT%T%z)
-            ghp-import -m "Generate Pelican site ${timestamp}" --no-history --branch gh-pages  output
+            ghp-import -m "Generate Pelican site ${timestamp}" --no-history --cname 'conference.scipy.org' --branch gh-pages  output
             git push --force origin gh-pages
         

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: make install
+        run: make init
 
       - name: Build website
         run: make clean && make publish


### PR DESCRIPTION
This is a follow-up to #51 with fixes:

- Fix `make` target to install dependencies
- Enable the workflow to write to the repo, which we need to write to the `gh-pages` branch.
- Force-push the `gh-pages` branch because we're overwriting the content every time.
- Specify the CNAME so we can redirect from conference.scipy.org.  Github automatically adds a CNAME file if you're publishing from a branch. But since the action wipes the `gh-pages` branch every time, the CNAME file goes away. ghp-import has the option to recreate it every time.
