### PR TITLE
ci: Use GitHub Actions to perform deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,18 @@ name: Deploy to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["main"]
+
+  # Ensure the docs build on PR
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Build job
@@ -40,11 +36,37 @@ jobs:
       - name: Build website
         run: make clean && make publish
 
-      - name: Commit output to gh-pages branch
+      - name: Fix permissions if needed
         run: |
-            git config user.name "Automated"
-            git config user.email "actions@users.noreply.github.com"
-            timestamp=$(date -u +%FT%T%z)
-            ghp-import -m "Generate Pelican site ${timestamp}" --no-history --cname 'conference.scipy.org' --branch gh-pages  output
-            git push --force origin gh-pages
-        
+          chmod -c -R +rX "output/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'output/'
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Deploy on push event to main or with any branch and workflow dispatch
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    needs: build
+    # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Edits PR #52 (though if it is perferable I can just rebase this against `main` and supersede it instead)

* Run on push events to 'main' as the default branch has been renamed from 'master'.
* Add running the build job on pull_request events to allow testing builds of the website in advance.
* Scope concurrency to the workflow level, which allows for per branch runs to not conflict.
* Split the workflow into a build and deploy job. In the build job have the built website be uploaded as a run artifact. In the deploy job this artifact is then downloaded and and deployed to GitHub Pages.
   - For the deploy job, set the permissions to allow for the default GITHUB_TOKEN to perform the deployment.
   - Use the github-pages environment as required by GitHub Actions.
   - Run the deploy job on either:
      * push events to main (a merged PR)
      * workflow_dispatch events that happen on any branch, to allow for hotfixing

This also allows us to not use `ghp-import` which is a project that is unmatained.