### PR TITLE
chore: Remove unused ghp-import dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "hatchling.build"
 name = "conference_scipy"
 classifiers = ["Private :: Do Not Upload"]
 version = "0"
-dependencies = ["markdown", "pelican", "ghp-import"]
+dependencies = ["markdown", "pelican"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ docutils==0.20.1
     # via pelican
 feedgenerator==2.1.0
     # via pelican
-ghp-import==2.1.0
-    # via conference_scipy (pyproject.toml)
 idna==3.6
     # via anyio
 jinja2==3.1.3
@@ -35,9 +33,7 @@ pygments==2.17.2
     #   pelican
     #   rich
 python-dateutil==2.9.0.post0
-    # via
-    #   ghp-import
-    #   pelican
+    # via pelican
 pytz==2024.1
     # via feedgenerator
 rich==13.7.1


### PR DESCRIPTION
* As ghp-import is not used there is no need to install it.
* Amends PR https://github.com/scipy-conference/conference.scipy.org/pull/52