### PR TITLE
Added SciPy 2024 and 2025 dates

### DIFF
--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -22,4 +22,5 @@ We're currently moving the Proceedings and some file may be temporarily unavaila
 - [SciPy 2021](https://proceedings.scipy.org/2021)
 - [SciPy 2022](https://proceedings.scipy.org/2022)
 - [SciPy 2023](https://proceedings.scipy.org/2023)
+- [SciPy 2024](https://proceedings.scipy.org/2024)
 

--- a/content/pages/past.md
+++ b/content/pages/past.md
@@ -2,6 +2,10 @@ Title: Past Conferences
 URL: past.html
 Save_as: past.html
 
+## 2024
+* [SciPy 2024](https://www.scipy2024.scipy.org/) 
+* [EuroSciPy 2024](https://euroscipy.org/2024/)
+
 ## 2023
 * [SciPy 2023](https://www.scipy2023.scipy.org/) 
 * [EuroSciPy 2023](https://euroscipy.org/2023/)

--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -5,6 +5,9 @@ Save_as: proceedings/index.html
 **ISSN: 2575-9752**
 **[https://doi.org/10.25080/issn.2575-9752](https://doi.org/10.25080/issn.2575-9752)**
 
+**[SciPy 2024](https://proceedings.scipy.org/2024)**
+ *23rd Python in Science Conference - Tacoma, Washington (July 8-14, 2024)*
+ 
 **[SciPy 2023](https://proceedings.scipy.org/2023)**
  *22nd Python in Science Conference - Austin, Texas (July 10–16, 2023)*
 

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -22,6 +22,9 @@ The conferences generally consists of multiple days of tutorials followed by two
 <h3><a href="https://scipy2024.scipy.org/">SciPy 2024</a></h3>
 <p>Tacoma, WA, July 8-14, 2024</p>
 
+<h3><a href="https://euroscipy.org/2025/">EuroSciPy 2025</a></h3>
+<p>Krakow, Poland, August 18-22, 2025</p>
+
 </div>
 
 

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -4,7 +4,7 @@
 <div style="width:45%; float:left;">
 <h2>About</h2>
 <p>
-The annual SciPy Conferences allows participants from academic, commercial, and governmental organizations to:
+The annual SciPy Conference allows participants from academic, commercial, and governmental organizations to:
 </p>
 <ul>
 <li>showcase their latest Scientific Python projects, </li>
@@ -12,7 +12,7 @@ The annual SciPy Conferences allows participants from academic, commercial, and 
 <li>collaborate on code development. </li>
 </ul>
 <p>
-The conferences generally consists of multiple days of tutorials followed by two-three days of presentations, and concludes with 1-2 days developer sprints on projects of interest to the attendees.
+The conference generally consists of multiple days of tutorials followed by two-three days of presentations, and concludes with 1-2 days developer sprints on projects of interest to the attendees.
 </p>
 </div>
 


### PR DESCRIPTION
My changes are related to PR #63:

1. Updated the list of past conferences to include 2024.
2. Added the EuroSciPy 2025 conference link to the homepage.
3. Corrected grammatical errors in the About section.