### PR TITLE
add EuroSciPy and SciPy 2025

### DIFF
--- a/content/pages/past.md
+++ b/content/pages/past.md
@@ -2,6 +2,10 @@ Title: Past Conferences
 URL: past.html
 Save_as: past.html
 
+## 2024
+* [SciPy 2024](https://www.scipy2024.scipy.org/) 
+* [EuroSciPy 2024](https://euroscipy.org/2024/)
+
 ## 2023
 * [SciPy 2023](https://www.scipy2023.scipy.org/) 
 * [EuroSciPy 2023](https://euroscipy.org/2023/)

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,8 +19,11 @@ The conferences generally consists of multiple days of tutorials followed by two
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="https://scipy2024.scipy.org/">SciPy 2024</a></h3>
-<p>Tacoma, WA, July 8-14, 2024</p>
+<h3><a href="https://scipy2025.scipy.org/">SciPy 2025</a></h3>
+<p>Tacoma, WA, July 7-13, 2025</p>
+
+<h3><a href="https://euroscipy.org/2025/">EuroSciPy 2025</a></h3>
+<p>Krakow, Poland, August 18-22, 2025</p>
 
 </div>
 


### PR DESCRIPTION
* adds entries at https://conference.scipy.org/past.html for EuroSciPy and SciPy 2024
* adds entries on the homepage for EuroSciPy and SciPy 2025

## Notes for Reviewers

I originally noticed this because https://wiki.python.org/moin/PythonConferences links to https://conference.scipy.org/index.html for SciPy.