### PR TITLE
Added SciPyData Japan for January 2025

### DIFF
--- a/content/pages/past.md
+++ b/content/pages/past.md
@@ -2,6 +2,9 @@ Title: Past Conferences
 URL: past.html
 Save_as: past.html
 
+## 2025
+* [SciPyData Japan 2025](https://scipydata.connpass.com/)
+
 ## 2024
 * [SciPy 2024](https://www.scipy2024.scipy.org/) 
 * [EuroSciPy 2024](https://euroscipy.org/2024/)


### PR DESCRIPTION
According to [scipy.org/pull/610](https://github.com/scipy/scipy.org/pull/610), the SciPyData Japan conference was held in January 2025. 

The website is: https://scipydata.connpass.com/