### PR TITLE
add SciPy and EuroSciPy 2026

### DIFF
--- a/content/pages/past.md
+++ b/content/pages/past.md
@@ -2,6 +2,10 @@ Title: Past Conferences
 URL: past.html
 Save_as: past.html
 
+## 2025
+* [SciPy 2025](https://www.scipy2025.scipy.org/) 
+* [EuroSciPy 2025](https://archive.euroscipy.org/2025/)
+
 ## 2024
 * [SciPy 2024](https://www.scipy2024.scipy.org/) 
 * [EuroSciPy 2024](https://euroscipy.org/2024/)

--- a/content/pages/proceedings.md
+++ b/content/pages/proceedings.md
@@ -5,6 +5,9 @@ Save_as: proceedings/index.html
 **ISSN: 2575-9752**
 **[https://doi.org/10.25080/issn.2575-9752](https://doi.org/10.25080/issn.2575-9752)**
 
+**[SciPy 2025](https://proceedings.scipy.org/2025)**
+ *24th Python in Science Conference - Tacoma, Washington (July 7-13, 2025)*
+
 **[SciPy 2024](https://proceedings.scipy.org/2024)**
  *23rd Python in Science Conference - Tacoma, Washington (July 8-14, 2024)*
  

--- a/theme/tuxlite_zf/templates/index.html
+++ b/theme/tuxlite_zf/templates/index.html
@@ -19,11 +19,11 @@ The conference generally consists of multiple days of tutorials followed by two-
 <div style="width:45%; float: right;">
 <h2>Upcoming</h2>
 
-<h3><a href="https://scipy2025.scipy.org/">SciPy 2025</a></h3>
-<p>Tacoma, WA, July 7-13, 2025</p>
+<h3><a href="https://scipy2026.scipy.org/">SciPy 2026</a></h3>
+<p>Minneapolis, MN, July 13-19, 2026</p>
 
-<h3><a href="https://euroscipy.org/2025/">EuroSciPy 2025</a></h3>
-<p>Krakow, Poland, August 18-22, 2025</p>
+<h3><a href="https://euroscipy.org/">EuroSciPy 2026</a></h3>
+<p>Krakow, Poland, July 18-23, 2026</p>
 
 </div>
 


### PR DESCRIPTION
Updates https://conference.scipy.org/index.html with the following:

* SciPy 2026
* EuroScipy 2026
* links to the proceedings and websites of the 2025 instances of those conferences